### PR TITLE
Fixes telegram terminating all sessions when using the script

### DIFF
--- a/src/backup/__main__.py
+++ b/src/backup/__main__.py
@@ -27,7 +27,7 @@ if os.path.exists(session_file):
     print(f"Existing session file removed: {session_file}")
 
 # Initialize Telegram client
-client: TelegramClient = TelegramClient(session_name, api_id, api_hash)
+client: TelegramClient = TelegramClient(session_name, api_id, api_hash, app_version="tg-message-lifeguard")
 
 
 async def export_messages(


### PR DESCRIPTION
When running this script, I ran into a problem: after a couple of hundred messages, telegram sessions on all my devices would terminate.
The issue would disappear when I used custom system_version or app_version arguments in the TelegramClient function.
Apparently, telegram dislikes rapid requests made with the default telethon user agent, and is more likely to view such actions as suspicious, especially when made with accounts using Russian phone numbers. 