### PR TITLE
fix: replace deprecated event loop usage with asyncio.run

### DIFF
--- a/src/backup/__main__.py
+++ b/src/backup/__main__.py
@@ -146,5 +146,4 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())


### PR DESCRIPTION
added support for python 3.14.
This should theoretically still work for older versions